### PR TITLE
Add `allow_nil` option and show default values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,19 @@ user.archived!
 
 ## Options
 
-Choose which features you want with:
+Choose which features you want with (default values shown):
 
 ```ruby
 class User < ActiveRecord::Base
   str_enum :status, [:active, :archived],
-    scopes: false,
-    validate: false,
-    accessor_methods: false,
-    update_methods: false,
-    default: nil
+    accessor_methods: true,
+    allow_nil: false
+    default: true,
+    prefix: false,
+    scopes: true,
+    suffix: false,    
+    update_methods: true,
+    validate: true
 end
 ```
 


### PR DESCRIPTION
1. `allow_nil` was missing and I had to find this out via the code itself. (Glad it's built-in though!)

2. I find it more useful to show the default values for the options in the README. This way you can see what things may need to be changed.