### PR TITLE
Fix #14: attribute setting on loading from DB

### DIFF
--- a/lib/str_enum/model.rb
+++ b/lib/str_enum/model.rb
@@ -38,7 +38,7 @@ module StrEnum
         end
         default_value = default == true ? values.first : default
         after_initialize do
-          send("#{column}=", default_value) if has_attribute?(column) && !try(column)
+          send("#{column}=", default_value) if !persisted? && has_attribute?(column) && !try(column)
         end
         define_singleton_method column.to_s.pluralize do
           values

--- a/test/str_enum_test.rb
+++ b/test/str_enum_test.rb
@@ -86,4 +86,10 @@ class StrEnumTest < Minitest::Test
     assert_equal 0, User.not_active.count
     assert_equal 1, User.not_archived.count
   end
+
+  def test_attr_readonly
+    user = User.create!
+    # Should not raise
+    User.find(user.id)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "minitest/autorun"
 require "minitest/pride"
 require "active_record"
 
+ActiveRecord.raise_on_assign_to_attr_readonly = true
 ActiveRecord::Base.logger = Logger.new(ENV["VERBOSE"] ? STDOUT : nil)
 ActiveRecord::Migration.verbose = ENV["VERBOSE"]
 
@@ -15,6 +16,7 @@ ActiveRecord::Schema.define do
     t.string :status
     t.string :address_status
     t.string :kind
+    t.string :type
   end
 end
 
@@ -22,4 +24,7 @@ class User < ActiveRecord::Base
   str_enum :status, [:active, :archived]
   str_enum :address_status, [:active, :archived], prefix: :address
   str_enum :kind, [:guest, :vip], suffix: true
+  str_enum :type, [:permanent, :temporary], allow_nil: true, default: nil
+
+  attr_readonly :type
 end


### PR DESCRIPTION
Fixes the problem with `attr_readonly` setting by avoiding any assignment on loading of persisted models. 

I am not 100% sure this is a proper solution, but no tests fail :shrug: 